### PR TITLE
Replace custom ExitStatus with std::process::ExitStatus using a hack

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -41,7 +41,8 @@ struct State {
 
 type StateMap = HashMap<c_int, (File, Option<ExitStatus>)>;
 
-#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+// This should be exactly the same as std::sys::unix::process::ExitStatus!
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct ExitStatus(c_int);
 
 pub fn wait_timeout(child: &mut Child, dur: Duration)
@@ -267,30 +268,4 @@ fn now_ns() -> u64 {
 extern fn sigchld_handler(_signum: c_int) {
     let state = unsafe { &*STATE };
     notify(&state.write);
-}
-
-impl ExitStatus {
-    pub fn success(&self) -> bool {
-        self.code() == Some(0)
-    }
-
-    pub fn code(&self) -> Option<i32> {
-        unsafe {
-            if libc::WIFEXITED(self.0) {
-                Some(libc::WEXITSTATUS(self.0))
-            } else {
-                None
-            }
-        }
-    }
-
-    pub fn unix_signal(&self) -> Option<i32> {
-        unsafe {
-            if !libc::WIFEXITED(self.0) {
-                Some(libc::WTERMSIG(self.0))
-            } else {
-                None
-            }
-        }
-    }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -17,7 +17,8 @@ extern "system" {
     fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: LPDWORD) -> BOOL;
 }
 
-#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+// This should be exactly the same as std::sys::windows::process::ExitStatus!
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct ExitStatus(DWORD);
 
 pub fn wait_timeout(child: &mut Child, dur: Duration)
@@ -44,10 +45,3 @@ pub fn wait_timeout(child: &mut Child, dur: Duration)
         }
     }
 }
-
-impl ExitStatus {
-    pub fn success(&self) -> bool { self.code() == Some(0) }
-    pub fn code(&self) -> Option<i32> { Some(self.0 as i32) }
-    pub fn unix_signal(&self) -> Option<i32> { None }
-}
-


### PR DESCRIPTION
The motivation for doing this is to make API compatible and composable with `std::process::Command`. For example, this will allow to implement extension of `Command::wait_with_output` accepting a timeout.
I will probably burn in hell for this hack, but…

@alexcrichton What do you think, is such a hack acceptable for this crate?
