### PR TITLE
Drop stdin before waiting for the child process

### DIFF
--- a/src/bin/reader.rs
+++ b/src/bin/reader.rs
@@ -1,0 +1,7 @@
+use std::io::{Read, stdin};
+
+#[allow(unused_must_use)]
+fn main() {
+    let mut buffer: [u8; 32] = Default::default();
+    stdin().read(&mut buffer);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ pub trait ChildExt {
 
 impl ChildExt for Child {
     fn wait_timeout(&mut self, dur: Duration) -> io::Result<Option<ExitStatus>> {
+        drop(self.stdin.take());
         imp::wait_timeout(self, dur).map(|m| m.map(ExitStatus))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! on a child process with a timeout specified. On Windows the implementation
 //! is fairly trivial as it's just a call to `WaitForSingleObject` with a
 //! timeout argument, but on Unix the implementation is much more involved. The
-//! current implementation registeres a `SIGCHLD` handler and initializes some
+//! current implementation registers a `SIGCHLD` handler and initializes some
 //! global state. This handler also works within multi-threaded environments.
 //! If your application is otherwise handling `SIGCHLD` then bugs may arise.
 //!
@@ -59,7 +59,7 @@ pub trait ChildExt {
         self.wait_timeout(Duration::from_millis(ms as u64))
     }
 
-    /// Wait for this child to exit, timing out after `ms` milliseconds have
+    /// Wait for this child to exit, timing out after the duration `dur` has
     /// elapsed.
     ///
     /// If `Ok(None)` is returned then the timeout period elapsed without the


### PR DESCRIPTION
The behavior is not consistent with Rust's standard library. When you call [`wait`](https://doc.rust-lang.org/std/process/struct.Child.html#method.wait), stdlib closes the child's standard input handle. As this library isn't doing it, you have to close the child's standard input manually if you don't want it to timeout when the child process reads from its standard input.

@alexcrichton Do you want me to add tests in this PR ?