### PR TITLE
Use the respective method to convert to milliseconds

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,9 +15,7 @@ extern "system" {
 
 pub fn wait_timeout(child: &mut Child, dur: Duration)
                        -> io::Result<Option<ExitStatus>> {
-    let ms = dur.as_secs().checked_mul(1000).and_then(|amt| {
-        amt.checked_add((dur.subsec_nanos() / 1_000_000) as u64)
-    }).expect("failed to convert duration to milliseconds");
+    let ms = dur.as_millis();
     let ms = if ms > (DWORD::max_value() as u64) {
         DWORD::max_value()
     } else {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -16,7 +16,7 @@ extern "system" {
 pub fn wait_timeout(child: &mut Child, dur: Duration)
                        -> io::Result<Option<ExitStatus>> {
     let ms = dur.as_millis();
-    let ms = if ms > (DWORD::max_value() as u64) {
+    let ms = if ms > (DWORD::max_value() as u128) {
         DWORD::max_value()
     } else {
         ms as DWORD


### PR DESCRIPTION
The problem with the current implementaion is the the overflow for large numbers. I used `u64::max_value()` as default value so the program runs (almost) indefinitely, but on Windows, I saw that the tests panicked. And since there is already a dedicated method, which doesn't panic, I added it.