### PR TITLE
Follow-up of #19 and more documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,17 @@
 //!
 //! This crate is an implementation for Unix and Windows of the ability to wait
 //! on a child process with a timeout specified. On Windows the implementation
-//! is fairly trivial as it's just a call to `WaitForSingleObject` with a
-//! timeout argument, but on Unix the implementation is much more involved. The
+//! is fairly trivial as it's just a call to [`WaitForSingleObject`] with a
+//! timeout argument. The maximum timeout is therefore `u32::max_value()` milliseconds.
+//!
+//! But on Unix on the other hand, the implementation is much more involved. The
 //! current implementation registers a `SIGCHLD` handler and initializes some
 //! global state. This handler also works within multi-threaded environments.
 //! If your application is otherwise handling `SIGCHLD` then bugs may arise.
+//! Because of the usage of [`poll`], the maximum timout is only `u16::max_value()`.
+//!
+//! [`WaitForSingleObject`]: https://docs.microsoft.com/en-us/windows/desktop/api/synchapi/nf-synchapi-waitforsingleobject
+//! [`poll`]: http://man7.org/linux/man-pages/man2/poll.2.html
 //!
 //! # Example
 //!

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -164,11 +164,7 @@ impl State {
                 break
             }
             let timeout = dur - elapsed;
-            let timeout = timeout.as_secs().checked_mul(1_000)
-                .and_then(|amt| {
-                    amt.checked_add(timeout.subsec_nanos() as u64 / 1_000_000)
-                })
-                .unwrap_or(u64::max_value());
+            let timeout = timeout.as_millis() as u64;
             let timeout = cmp::min(<c_int>::max_value() as u64, timeout) as c_int;
             let r = unsafe {
                 libc::poll(fds.as_mut_ptr(), 2, timeout)


### PR DESCRIPTION
After the change to `as_millis` for Windows, I changed it here as well. Because the method is only supported since Rust 1.33, the 1.21 build on Travis is failing. Is that a problem? 

I also added a little bit more information about the underlying mechanisms and their limitations as you suggested.