### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ travis-ci = { repository = "alexcrichton/wait-timeout" }
 appveyor = { repository = "alexcrichton/wait-timeout" }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = "0.2.56"

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -24,12 +24,12 @@ use std::os::unix::net::UnixStream;
 use std::mem;
 use std::os::unix::prelude::*;
 use std::process::{Child, ExitStatus};
-use std::sync::{Once, ONCE_INIT, Mutex};
+use std::sync::{Once, Mutex};
 use std::time::{Duration, Instant};
 
 use libc::{self, c_int};
 
-static INIT: Once = ONCE_INIT;
+static INIT: Once = Once::new();
 static mut STATE: *mut State = 0 as *mut _;
 
 struct State {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -193,9 +193,8 @@ impl State {
             }
         }
 
-        let mut map = self.map.lock().unwrap();
-        let (_write, ret) = map.remove(&(remove.child as *mut Child)).unwrap();
-        drop(map);
+        // drop impl on Remove will remove this child from the map
+
         Ok(ret)
     }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -49,17 +49,6 @@ pub fn wait_timeout(child: &mut Child, dur: Duration)
     }
 }
 
-// Do $value as type_of($target)
-macro_rules! _as {
-    ($value:expr, $target:expr) => (
-        {
-            let mut x = $target;
-            x = $value as _;
-            x
-        }
-    )
-}
-
 impl State {
     #[allow(unused_assignments)]
     fn init() {
@@ -80,16 +69,7 @@ impl State {
             // Register our sigchld handler
             let mut new: libc::sigaction = mem::zeroed();
             new.sa_sigaction = sigchld_handler as usize;
-
-            // FIXME: remove this workaround when the PR to libc get merged and released
-            //
-            // This is a workaround for the type mismatch in the definition of SA_*
-            // constants for android. See https://github.com/rust-lang/libc/pull/511
-            //
-            let sa_flags = new.sa_flags;
-            new.sa_flags = _as!(libc::SA_NOCLDSTOP, sa_flags) |
-                           _as!(libc::SA_RESTART, sa_flags) |
-                           _as!(libc::SA_SIGINFO, sa_flags);
+            new.sa_flags = libc::SA_NOCLDSTOP | libc::SA_RESTART | libc::SA_SIGINFO;
 
             assert_eq!(libc::sigaction(libc::SIGCHLD, &new, &mut state.prev), 0);
 
@@ -289,12 +269,7 @@ extern fn sigchld_handler(signum: c_int,
         if fnptr == 0 {
             return
         }
-        // FIXME: remove this workaround when the PR to libc get merged and released
-        //
-        // This is a workaround for the type mismatch in the definition of SA_*
-        // constants for android. See https://github.com/rust-lang/libc/pull/511
-        //
-        if state.prev.sa_flags & _as!(libc::SA_SIGINFO, state.prev.sa_flags) == 0 {
+        if state.prev.sa_flags & libc::SA_SIGINFO == 0 {
             let action = mem::transmute::<usize, FnHandler>(fnptr);
             action(signum)
         } else {


### PR DESCRIPTION
Just a couple changes to make this crate compile warning-free with Rust 1.38.0+, and also drop some unnecessary code.