### PR TITLE
Revert "Do not manually remove the child from the map"

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -193,8 +193,9 @@ impl State {
             }
         }
 
-        // drop impl on Remove will remove this child from the map
-
+        let mut map = self.map.lock().unwrap();
+        let (_write, ret) = map.remove(&(remove.child as *mut Child)).unwrap();
+        drop(map);
         Ok(ret)
     }
 


### PR DESCRIPTION
This reverts commit 2291e8ab6881d551464cc4dfe0e3d62e3588ff33.

That commit doesn't compile, and it can't be made correct because we
have to return the child's status — we can't simply let the map entry
drop.

Thanks a ton to @mathstuf for spotting this, and my apologies for
not testing it before submitting a PR. This is so embarrassing >_<

(And yes, I did run `cargo build` and `cargo test` on this revert. It
builds and passes tests.)