### PR TITLE
Clean up Windows implementation slightly

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -18,7 +18,7 @@ pub fn wait_timeout(child: &mut Child, mut dur: Duration) -> io::Result<Option<E
     loop {
         let elapsed = start.elapsed();
         if elapsed >= dur {
-            break;
+            return Ok(None);
         }
         let timeout = dur - elapsed;
         let ms = timeout.as_millis();

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::os::windows::prelude::*;
 use std::process::{Child, ExitStatus};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 type DWORD = u32;
 type HANDLE = *mut u8;
@@ -13,19 +13,23 @@ extern "system" {
     fn WaitForSingleObject(hHandle: HANDLE, dwMilliseconds: DWORD) -> DWORD;
 }
 
-pub fn wait_timeout(child: &mut Child, dur: Duration) -> io::Result<Option<ExitStatus>> {
-    let ms = dur.as_millis();
-    let ms = if ms > (DWORD::max_value() as u128) {
-        DWORD::max_value()
-    } else {
-        ms as DWORD
-    };
-    unsafe {
-        match WaitForSingleObject(child.as_raw_handle() as *mut _, ms) {
-            WAIT_OBJECT_0 => {}
-            WAIT_TIMEOUT => return Ok(None),
-            _ => return Err(io::Error::last_os_error()),
+pub fn wait_timeout(child: &mut Child, mut dur: Duration) -> io::Result<Option<ExitStatus>> {
+    let start = Instant::now();
+    loop {
+        let elapsed = start.elapsed();
+        if elapsed >= dur {
+            break;
         }
+        let timeout = dur - elapsed;
+        let ms = timeout.as_millis();
+        let ms = DWORD::try_from(ms).unwrap_or(DWORD::MAX);
+        unsafe {
+            match WaitForSingleObject(child.as_raw_handle().cast(), ms) {
+                WAIT_OBJECT_0 => {}
+                WAIT_TIMEOUT => return Ok(None),
+                _ => return Err(io::Error::last_os_error()),
+            }
+        }
+        return child.try_wait();
     }
-    child.try_wait()
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -13,7 +13,7 @@ extern "system" {
     fn WaitForSingleObject(hHandle: HANDLE, dwMilliseconds: DWORD) -> DWORD;
 }
 
-pub fn wait_timeout(child: &mut Child, mut dur: Duration) -> io::Result<Option<ExitStatus>> {
+pub fn wait_timeout(child: &mut Child, dur: Duration) -> io::Result<Option<ExitStatus>> {
     let start = Instant::now();
     loop {
         let elapsed = start.elapsed();


### PR DESCRIPTION
* Modernize fallible casts.
* Add a loop which pumps until `dur` is drained.

Closes #23